### PR TITLE
chore: update to nodejs 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Allows you to perform a rollback to the previous live version of the targeted ap
 ### Login and get access to our licensed products (for functional test purposes for example):
 
 ```yaml
-uses: kuzzleio/paas-action@v0.7.0
+uses: kuzzleio/paas-action@v1.1.0
 with:
   username: ${{ secrets.KUZZLE_PAAS_USERNAME }}
   password: ${{ secrets.KUZZLE_PAAS_PASSWORD }}
@@ -61,7 +61,7 @@ with:
 ### Deploy a new version of your application on your Kuzzle PaaS environment:
 
 ```yaml
-uses: kuzzleio/paas-action@v0.7.0
+uses: kuzzleio/paas-action@v1.1.0
 with:
   username: ${{ secrets.KUZZLE_PAAS_USERNAME }}
   password: ${{ secrets.KUZZLE_PAAS_PASSWORD }}
@@ -77,7 +77,7 @@ with:
 > NOTE: It will rollback to the previous live version of the targeted application.
 
 ```yaml
-uses: kuzzleio/paas-action@v0.7.0
+uses: kuzzleio/paas-action@v1.1.0
 with:
   username: ${{ secrets.KUZZLE_PAAS_USERNAME }}
   password: ${{ secrets.KUZZLE_PAAS_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
     default: "60"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paas-action",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What does this PR do ?

Following the deprecation of Node.js 16 by GitHub, this updates the version of Node.js used by this action to 20.

### Other changes

The `README` and `package.json` files were updated to reflect the version that will be released (`v1.1.0`).